### PR TITLE
install the FSRM Windows feature on 2016

### DIFF
--- a/bosh-psmodules/modules/BOSH.CFCell/BOSH.CFCell.psm1
+++ b/bosh-psmodules/modules/BOSH.CFCell/BOSH.CFCell.psm1
@@ -22,6 +22,8 @@ function Install-CFFeatures {
     WindowsFeatureInstall("Web-WHC")
     WindowsFeatureInstall("Web-ASP")
   } elseif ($windowsVersion -Match "2016") {
+    WindowsFeatureInstall("FS-Resource-Manager")
+  
     if ((Get-Command "docker.exe" -ErrorAction SilentlyContinue) -eq $null) {
       Write-Host "Installing Docker"
 


### PR DESCRIPTION
necessary for garden-windows container disk limits to work