### PR TITLE
Allow the use of private IPs when connecting to the Packer VM.

### DIFF
--- a/lib/packer/config/aws.rb
+++ b/lib/packer/config/aws.rb
@@ -34,7 +34,7 @@ module Packer
             ami_name: "BOSH-#{SecureRandom.uuid}-#{@region[:name]}",
             vpc_id: @region[:vpc_id],
             subnet_id: @region[:subnet_id],
-            associate_public_ip_address: true,
+            associate_public_ip_address: !@region[:use_private_ip_address],
             launch_block_device_mappings: launch_block_device_mappings,
             communicator: 'winrm',
             winrm_username: 'Administrator',

--- a/spec/packer/config/aws_spec.rb
+++ b/spec/packer/config/aws_spec.rb
@@ -91,7 +91,8 @@ describe Packer::Config::Aws do
             base_ami: 'baseami1',
             vpc_id: 'vpc1',
             subnet_id: 'subnet1',
-            security_group: 'sg1'
+            security_group: 'sg1',
+            use_private_ip_address: true
         }
 
         gov_builders = Packer::Config::Aws.new(
@@ -107,7 +108,8 @@ describe Packer::Config::Aws do
 
         expect(gov_builders[0]).to include(baseline_builders.merge({
                                                                        region: 'region1-gov',
-                                                                       name: "amazon-ebs-region1-gov"}))
+                                                                       name: "amazon-ebs-region1-gov",
+                                                                       associate_public_ip_address: false}))
         expect(gov_builders[0][:ami_name]).to match(/BOSH-.*-region1/)
         expect(gov_builders[0][:user_data_file]).to match(/.*scripts\/aws\/setup_winrm.txt$/)
       end


### PR DESCRIPTION
Public IP addresses aren't allowed in some AWS secret regions, such as
us-iso-east-1.  This flag allows users in those environments to override the
default behavior and launch the packer VM without a public IP.  In that case,
packer will manage the VM using the private IP.