### PR TITLE
Add rake tasks to label gcp stemcells for test and production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ vendor/cache/ruby/
 
 /build
 /local-builders
+.idea

--- a/lib/stemcell/labeler/gcp.rb
+++ b/lib/stemcell/labeler/gcp.rb
@@ -1,0 +1,20 @@
+require_relative '../../exec_command'
+
+module Stemcell
+	module Labeler
+		class Gcp
+			def self.label(image_url, account_json, key, value)
+				account_data = JSON.parse(account_json)
+				project_id = account_data['project_id']
+				image_name = File.basename(image_url)
+
+				Tempfile.create(['account','.json']) do |f|
+					f.write(account_json)
+					f.close
+					exec_command("gcloud auth activate-service-account --quiet --key-file #{f.path}")
+					exec_command("gcloud compute images add-labels #{image_name} --labels=#{key}=#{value} --project #{project_id}")
+				end
+			end
+		end
+	end
+end


### PR DESCRIPTION
This will allow us to clean up unpublished gcp images at a
later date

[#178664602]

Signed-off-by: Joseph Palermo <jpalermo@pivotal.io>
Co-authored-by: Joseph Palermo <jpalermo@pivotal.io>