### PR TITLE
Update pester invocation script to use Pester 5

### DIFF
--- a/ci/pipelines/stemcells-windows-2019.yml
+++ b/ci/pipelines/stemcells-windows-2019.yml
@@ -683,7 +683,6 @@ jobs:
     - in_parallel:
         fail_fast: true
         steps:
-          - get: pester
           - get: bosh-windows-stemcell-builder-ci
           - get: stemcell-builder
             trigger: true

--- a/ci/tasks/test-units-bosh-psmodules/run.ps1
+++ b/ci/tasks/test-units-bosh-psmodules/run.ps1
@@ -1,20 +1,38 @@
-$ErrorActionPreference = "Stop"
-# Do not set error action preference let Pester handle it instead
-$result = 0
+function New-TemporaryDirectory {
+  $tmp = [System.IO.Path]::GetTempPath() # Not $env:TEMP, see https://stackoverflow.com/a/946017
+  $name = (New-Guid).ToString("N")
+  New-Item -ItemType Directory -Path (Join-Path $tmp $name)
+}
 
-Import-Module ./Pester/pester.psm1;
+$moduleDir = New-TemporaryDirectory
+$pesterModule = Find-Module -Name Pester -MaximumVersion "5.9999" -MinimumVersion "5.0"
+$pesterModule | Save-Module -Path $moduleDir
+
+Import-Module "$moduleDir\Pester\$($pesterModule.Version)\Pester.psm1"
+
 $status = (Get-Service -Name "wuauserv").Status
 $startupType = Get-Service "wuauserv" | Select-Object -ExpandProperty StartType | Out-String
 "wuauserv status = * $status *"
 "wuauserv startuptype = * $startupType *"
 
-foreach ($module in (Get-ChildItem "./stemcell-builder/modules").Name) {
-  Push-Location "./stemcell-builder/modules/$module"
+$result = 0
+
+$testModules =  Get-ChildItem "./bosh-psmodules-repo/modules/" -recurse | where {$_.name -match ".*.Tests.ps1"} | foreach {$_.DirectoryName}
+foreach ($module in $testModules) {
+    Write-Host "Testing: $module"
+    Push-Location "$module"
+
+    # Do not set $ErrorActionPreference and let Pester handle it nativetly; setting it to Stop globally will
+    # break the tests since they are written with the assumption non zero exit codes will not fail a test
+    # See: https://github.com/pester/Pester/issues/1404#issuecomment-568659518 for details
     $results=Invoke-Pester -PassThru
     if ($results.FailedCount -gt 0) {
       $result += $results.FailedCount
     }
-  Pop-Location
+
+    Pop-Location
 }
+
 echo "Failed Tests: $result"
 exit $result
+

--- a/ci/tasks/test-units-bosh-psmodules/task.yml
+++ b/ci/tasks/test-units-bosh-psmodules/task.yml
@@ -4,7 +4,6 @@ platform: windows
 inputs:
   - name: bosh-windows-stemcell-builder-ci
   - name: stemcell-builder
-  - name: pester
 
 run:
   path: powershell


### PR DESCRIPTION
It also switches how we fetch pester from a git repo to a binary install. I did try to preserve the old install method but it doesnt work quite right. So instead I went the precompiled binary method.