### PR TITLE
CI: also strip `"` from values

### DIFF
--- a/ci/tasks/aws-tag-image/run.sh
+++ b/ci/tasks/aws-tag-image/run.sh
@@ -21,7 +21,7 @@ if [ -n "${GREP_PATTERN}" ]; then
   AMI_LIST=$(echo "${AMI_LIST}" | eval "${GREP_PATTERN}")
 fi
 OS=$(grep "operating_system" stemcell.MF | cut -f2 -d: | tr -d ' ')
-VERSION=$(grep "^version" stemcell.MF | cut -f2 -d: | tr -d ' ' | tr -d "'")
+VERSION=$(grep "^version" stemcell.MF | cut -f2 -d: | tr -d ' ' | tr -d "'" | tr -d '"')
 
 for AMI_LINE in ${AMI_LIST}; do
   AMI_REGION=$(echo "${AMI_LINE}" | cut -f1 -d:)


### PR DESCRIPTION
The code which tags AMIs extracts version information from the stemcell manifest `stemcell.MF` which has contained single quotes `'`, and which can also (and now does) contain double quotes `"` to distinguish YAML (numeric) strings from numbers. This commit adds code to _also_ strip out double quotes.