### PR TITLE
Clean up remnants of manual OpenSSH installation

### DIFF
--- a/ci/pipelines/stemcells-windows.yml
+++ b/ci/pipelines/stemcells-windows.yml
@@ -208,13 +208,6 @@ resources:
     password: ((docker.password))
 
 # type: github-release
-- name: openssh-release
-  type: github-release
-  source:
-    owner: PowerShell
-    repository: Win32-OpenSSH
-    access_token: ((github_public_repo_token))
-    tag_filter: v([^v].*)
 - name: stemcell-builder-github-release
   type: github-release
   source:
@@ -797,8 +790,6 @@ jobs:
         tags: [*worker_tag]
       - get: bosh-windows-stemcell-builder-ci-image
         tags: [*worker_tag]
-      - get: open-ssh
-        resource: openssh-release
       - get: stemcell-builder
         passed: [build]
         tags: [*worker_tag]
@@ -910,8 +901,6 @@ jobs:
         tags: [*worker_tag]
       - get: bosh-windows-stemcell-builder-ci-image
         tags: [*worker_tag]
-      - get: open-ssh
-        resource: openssh-release
       - get: stemcell-builder
         passed: [build]
         tags: [*worker_tag]
@@ -1369,8 +1358,6 @@ jobs:
       - get: main-version
         passed: [build]
         tags: [*worker_tag]
-      - get: sshd
-        resource: openssh-release
       - get: bosh-agent-release
         passed: [build]
       - get: blobstore-dav-cli
@@ -1555,8 +1542,6 @@ jobs:
       - get: main-version
         passed: [wuts-aws]
         tags: [*worker_tag]
-      - get: sshd
-        resource: openssh-release
       - get: bosh-agent-release
         passed: [wuts-aws]
       - get: blobstore-dav-cli
@@ -1721,8 +1706,6 @@ jobs:
       - get: main-version
         passed: [build]
         tags: [*worker_tag]
-      - get: sshd
-        resource: openssh-release
       - get: bosh-agent-release
         passed: [build]
       - get: blobstore-dav-cli
@@ -1919,8 +1902,6 @@ jobs:
       - get: main-version
         passed: [build]
         tags: [*worker_tag]
-      - get: sshd
-        resource: openssh-release
       - get: bosh-agent-release
         passed: [build]
       - get: blobstore-dav-cli

--- a/ci/tasks/create-aws-stemcell/task.yml
+++ b/ci/tasks/create-aws-stemcell/task.yml
@@ -7,7 +7,6 @@ inputs:
   - name: base-amis
   - name: version
   - name: lgpo-binary
-  - name: sshd
   - name: packer-ci-private-key
   - name: bosh-agent-release
   - name: blobstore-dav-cli

--- a/ci/tasks/create-azure-stemcell/task.yml
+++ b/ci/tasks/create-azure-stemcell/task.yml
@@ -6,7 +6,6 @@ inputs:
   - name: version
   - name: stemcell-builder
   - name: lgpo-binary
-  - name: sshd
   - name: bosh-agent-release
   - name: blobstore-dav-cli
   - name: blobstore-s3-cli

--- a/ci/tasks/create-gcp-stemcell/task.yml
+++ b/ci/tasks/create-gcp-stemcell/task.yml
@@ -7,7 +7,6 @@ inputs:
   - name: base-gcp-image
   - name: version
   - name: lgpo-binary
-  - name: sshd
   - name: bosh-agent-release
   - name: blobstore-dav-cli
   - name: blobstore-s3-cli

--- a/ci/tasks/generate-deps-file/run.bash
+++ b/ci/tasks/generate-deps-file/run.bash
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-openssh_win64_sha256="$(shasum -a 256 open-ssh/OpenSSH-Win64.zip | cut -d " " -f 1)"
-openssh_win64_version="$(cat open-ssh/version)"
-
 psmodules_sha256="$(shasum -a 256 psmodules-zip-output/bosh-psmodules.zip | cut -d " " -f 1)"
 psmodules_version="$(cat version/version)"
 
@@ -15,10 +12,6 @@ lgpo_version="3"
 
 cat <<EOF > deps-file/deps.json
 {
-  "OpenSSH-Win64.zip": {
-    "sha": "${openssh_win64_sha256}",
-    "version": "${openssh_win64_version}"
-  },
   "bosh-psmodules.zip": {
     "sha": "${psmodules_sha256}",
     "version": "${psmodules_version}"

--- a/ci/tasks/generate-deps-file/task.yml
+++ b/ci/tasks/generate-deps-file/task.yml
@@ -4,7 +4,6 @@ platform: linux
 inputs:
   - name: bosh-windows-stemcell-builder-ci
   - name: stemcell-builder
-  - name: open-ssh
   - name: lgpo-binary
   - name: version
   - name: bosh-agent

--- a/ci/tasks/zip-files/run.bash
+++ b/ci/tasks/zip-files/run.bash
@@ -6,7 +6,6 @@ ROOT_DIR=$(pwd)
 REPO_ROOT="${REPO_ROOT:-"$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"}"
 ZIP_FILE_DESTINATION="${ZIP_FILE_DESTINATION:-"${ROOT_DIR}/zip-file/StemcellAutomation-$(date +"%s").zip"}"
 
-OPENSSH_ZIP="${OPENSSH_ZIP:-"${ROOT_DIR}/open-ssh/OpenSSH-Win64.zip"}"
 BOSH_PSMODULES_ZIP="${BOSH_PSMODULES_ZIP:-"${ROOT_DIR}/psmodules-zip-output/bosh-psmodules.zip"}"
 AGENT_ZIP="${AGENT_ZIP:-"${ROOT_DIR}/bosh-agent/agent.zip"}"
 DEPS_JSON="${DEPS_JSON:-"${ROOT_DIR}/deps-file/deps.json"}"
@@ -20,7 +19,7 @@ mkdir -p "${stemcell_automation_dir}"
 
 declare -a files_to_zip
 mapfile -t files_to_zip < <(find "${REPO_ROOT}/stembuild/stemcell-automation" -type f -not -name "*Test*" -name "*.ps*1")
-files_to_zip+=("${OPENSSH_ZIP}" "${BOSH_PSMODULES_ZIP}" "${AGENT_ZIP}" "${DEPS_JSON}")
+files_to_zip+=("${BOSH_PSMODULES_ZIP}" "${AGENT_ZIP}" "${DEPS_JSON}")
 
 cp "${files_to_zip[@]}" "${stemcell_automation_dir}"
 

--- a/ci/tasks/zip-files/task.yml
+++ b/ci/tasks/zip-files/task.yml
@@ -4,7 +4,6 @@ platform: linux
 inputs:
   - name: bosh-windows-stemcell-builder-ci
   - name: stemcell-builder
-  - name: open-ssh
   - name: deps-file
   - name: bosh-agent
   - name: psmodules-zip-output

--- a/lib/packer/config/templates/provision_windows2019.json.erb
+++ b/lib/packer/config/templates/provision_windows2019.json.erb
@@ -138,11 +138,6 @@
     ]
   },
   {
-    "type": "file",
-    "source": "../sshd/OpenSSH-Win64.zip",
-    "destination": "C:\\provision\\OpenSSH-Win64.zip"
-  },
-  {
     "type": "powershell",
     "inline": [
       "$ErrorActionPreference = \"Stop\";",

--- a/spec/packer/config/aws_spec.rb
+++ b/spec/packer/config/aws_spec.rb
@@ -189,7 +189,6 @@ describe Packer::Config::Aws do
           {"type" => "file", "source" => "hotfixes.log", "destination" => "hotfixes.log", "direction" => "download"},
           {"type" => "powershell", "inline" => ["$ErrorActionPreference = \"Stop\";", "trap { $host.SetShouldExit(1) }", "Remove-Account -User Provisioner"]},
           {"type" => "powershell", "inline" => ["$ErrorActionPreference = \"Stop\";", "trap { $host.SetShouldExit(1) }", "Protect-CFCell -IaaS aws"]},
-          {"type" => "file", "source" => "../sshd/OpenSSH-Win64.zip", "destination" => "C:\\provision\\OpenSSH-Win64.zip"},
           {"type" => "powershell", "inline" => ["$ErrorActionPreference = \"Stop\";", "trap { $host.SetShouldExit(1) }", "Install-SSHD"]},
           {"type"=>"powershell", "inline"=> ["$ErrorActionPreference = \"Stop\";", "trap { $host.SetShouldExit(1) }", "Enable-SSHD"]},
           {"type" => "file", "source" => "build/agent.zip", "destination" => "C:\\provision\\agent.zip"},

--- a/spec/packer/config/azure_spec.rb
+++ b/spec/packer/config/azure_spec.rb
@@ -130,7 +130,6 @@ describe Packer::Config::Azure do
           {"type" => "file", "source" => "hotfixes.log", "destination" => "hotfixes.log", "direction" => "download"},
           {"type" => "powershell", "inline" => ["$ErrorActionPreference = \"Stop\";", "trap { $host.SetShouldExit(1) }", "Remove-Account -User Provisioner"]},
           {"type" => "powershell", "inline" => ["$ErrorActionPreference = \"Stop\";", "trap { $host.SetShouldExit(1) }", "Protect-CFCell -IaaS azure"]},
-          {"type" => "file", "source" => "../sshd/OpenSSH-Win64.zip", "destination" => "C:\\provision\\OpenSSH-Win64.zip"},
           {"type" => "powershell", "inline" => ["$ErrorActionPreference = \"Stop\";", "trap { $host.SetShouldExit(1) }", "Install-SSHD"]},
           {"type"=>"powershell", "inline"=> ["$ErrorActionPreference = \"Stop\";", "trap { $host.SetShouldExit(1) }", "Enable-SSHD"]},
           {"type" => "file", "source" => "build/agent.zip", "destination" => "C:\\provision\\agent.zip"},

--- a/spec/packer/config/gcp_spec.rb
+++ b/spec/packer/config/gcp_spec.rb
@@ -118,7 +118,6 @@ describe Packer::Config::Gcp do
           {"type" => "file", "source" => "hotfixes.log", "destination" => "hotfixes.log", "direction" => "download"},
           {"type" => "powershell", "inline" => ["$ErrorActionPreference = \"Stop\";", "trap { $host.SetShouldExit(1) }", "Remove-Account -User Provisioner"]},
           {"type" => "powershell", "inline" => ["$ErrorActionPreference = \"Stop\";", "trap { $host.SetShouldExit(1) }", "Protect-CFCell -IaaS gcp"]},
-          {"type" => "file", "source" => "../sshd/OpenSSH-Win64.zip", "destination" => "C:\\provision\\OpenSSH-Win64.zip"},
           {"type" => "powershell", "inline" => ["$ErrorActionPreference = \"Stop\";", "trap { $host.SetShouldExit(1) }", "Install-SSHD"]},
           {"type"=>"powershell", "inline"=> ["$ErrorActionPreference = \"Stop\";", "trap { $host.SetShouldExit(1) }", "Enable-SSHD"]},
           {"type" => "file", "source" => "build/agent.zip", "destination" => "C:\\provision\\agent.zip"},

--- a/stembuild/stemcell-automation/AutomationHelpers.Tests.ps1
+++ b/stembuild/stemcell-automation/AutomationHelpers.Tests.ps1
@@ -1,9 +1,6 @@
-# We import module BOSH.SSH to ensure that we get the Install-SSHD function it defines. Starting with
-# OpenSSH 9.1, there is a conflicting install-sshd.ps1 script that takes precedence instead if you do
-# not load the module.
 BeforeAll {
-    Import-Module ../../modules/BOSH.SSH
     Import-Module ../../modules/BOSH.Utils
+    Import-Module ../../modules/BOSH.SSH
     Import-Module ../../modules/BOSH.CFCell
     Import-Module ../../modules/BOSH.Agent
     Import-Module ../../modules/BOSH.CFCell


### PR DESCRIPTION
As of July 2025 windows stemcells have converted to using Microsofts official OpenSSH installation method[1]. This commit removes the remnants of the prior installation method, and associated CI tooling.

[1] https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse