### PR TITLE
CI: remove unused input to copy-aws-stemcell

### DIFF
--- a/ci/tasks/copy-aws-stemcell/run
+++ b/ci/tasks/copy-aws-stemcell/run
@@ -19,11 +19,6 @@ else
   set -x
 fi
 
-CONCOURSE_ROOT="$(pwd)"
-
-"${CONCOURSE_ROOT}/bosh-windows-stemcell-builder-ci/ci/tasks/build-agent-zip/run.sh"
-"${CONCOURSE_ROOT}/bosh-windows-stemcell-builder-ci/ci/tasks/build-psmodules-zip/run.sh"
-
 pushd stemcell-builder
   bundle install --without test
 

--- a/ci/tasks/copy-aws-stemcell/task.yml
+++ b/ci/tasks/copy-aws-stemcell/task.yml
@@ -7,13 +7,6 @@ inputs:
   - name: version
   - name: amis
   - name: default-stemcell
-  - name: bosh-agent-release
-  - name: blobstore-dav-cli
-  - name: blobstore-s3-cli
-  - name: blobstore-gcs-cli
-  - name: windows-bsdtar
-  - name: windows-winsw
-
 
 outputs:
   - name: copied-regional-stemcells
@@ -30,4 +23,3 @@ params:
   VERSION_DIR: ../version
   AMIS_DIR: ../amis
   DEFAULT_STEMCELL_DIR: ../default-stemcell
-  BOSH_AGENT_DIR: bosh-agent-release


### PR DESCRIPTION
These may have been passed previously for tracking purposed in CI but are not currently used by this task, or any subsequent ones in CI.