### PR TITLE
Remove windows-bsdtar

### DIFF
--- a/acceptance_test/assets/bwats-release/jobs/check-system/templates/run.ps1
+++ b/acceptance_test/assets/bwats-release/jobs/check-system/templates/run.ps1
@@ -90,7 +90,6 @@ function Verify-Dependencies {
   [void] $files.AddRange((
       "bosh-blobstore-s3.exe",
       "bosh-blobstore-dav.exe",
-      "tar.exe",
       "job-service-wrapper.exe"
   ))
 

--- a/ci/pipelines/stemcells-windows.yml
+++ b/ci/pipelines/stemcells-windows.yml
@@ -314,14 +314,6 @@ resources:
   source:
     bucket: bosh-gcscli-artifacts
     regexp: bosh-gcscli-(.*)-windows-amd64.exe
-- name: windows-bsdtar
-  type: s3
-  source:
-    bucket: bosh-windows-dependencies
-    regexp: tar-(.*).exe
-    access_key_id: ((bosh_windows_ci_assume_aws_access_key.username))
-    secret_access_key: ((bosh_windows_ci_assume_aws_access_key.password))
-    aws_role_arn: ((bosh_windows_ci_assume_aws_access_key.role_arn))
 - name: windows-winsw
   type: s3
   source:
@@ -649,7 +641,6 @@ jobs:
       - get: blobstore-dav-cli
       - get: blobstore-s3-cli
       - get: blobstore-gcs-cli
-      - get: windows-bsdtar
       - get: windows-winsw
   - task: test-stemcell-builder
     file: bosh-windows-stemcell-builder-ci/ci/tasks/test-stemcell-builder/task.yml
@@ -803,7 +794,6 @@ jobs:
       - get: blobstore-dav-cli
       - get: blobstore-s3-cli
       - get: blobstore-gcs-cli
-      - get: windows-bsdtar
       - get: windows-winsw
   - put: version
     inputs: detect
@@ -931,7 +921,6 @@ jobs:
       - get: blobstore-dav-cli
       - get: blobstore-s3-cli
       - get: blobstore-gcs-cli
-      - get: windows-bsdtar
       - get: windows-winsw
   - put: version
     inputs: detect
@@ -1390,7 +1379,6 @@ jobs:
       - get: blobstore-dav-cli
       - get: blobstore-s3-cli
       - get: blobstore-gcs-cli
-      - get: windows-bsdtar
       - get: windows-winsw
   - put: version
     inputs: detect
@@ -1571,7 +1559,6 @@ jobs:
       - get: blobstore-dav-cli
       - get: blobstore-s3-cli
       - get: blobstore-gcs-cli
-      - get: windows-bsdtar
       - get: windows-winsw
   - task: create-aws-govcloud-stemcell
     timeout: 1h30m
@@ -1732,7 +1719,6 @@ jobs:
       - get: blobstore-dav-cli
       - get: blobstore-s3-cli
       - get: blobstore-gcs-cli
-      - get: windows-bsdtar
       - get: windows-winsw
   - put: version
     inputs: detect
@@ -1929,7 +1915,6 @@ jobs:
       - get: blobstore-dav-cli
       - get: blobstore-s3-cli
       - get: blobstore-gcs-cli
-      - get: windows-bsdtar
       - get: windows-winsw
   - put: version
     inputs: detect

--- a/ci/tasks/build-agent-zip/run.sh
+++ b/ci/tasks/build-agent-zip/run.sh
@@ -29,7 +29,6 @@ cp "${bosh_agent_resource_dir}/bosh-agent-pipe-${bosh_agent_resource_version}-wi
 cp "${CONCOURSE_ROOT}"/blobstore-gcs-cli/bosh-gcscli-*.exe "${zip_deps_dir}/bosh-blobstore-gcs.exe"
 cp "${CONCOURSE_ROOT}"/blobstore-dav-cli/davcli-*.exe "${zip_deps_dir}/bosh-blobstore-dav.exe"
 cp "${CONCOURSE_ROOT}"/blobstore-s3-cli/s3cli-*.exe "${zip_deps_dir}/bosh-blobstore-s3.exe"
-cp "${CONCOURSE_ROOT}"/windows-bsdtar/tar-*.exe "${zip_deps_dir}/tar.exe"
 cp "${CONCOURSE_ROOT}"/windows-winsw/WinSW.NET461.exe "${zip_deps_dir}/job-service-wrapper.exe"
 
 pushd "${zip_dir}"

--- a/ci/tasks/build-agent-zip/task.yml
+++ b/ci/tasks/build-agent-zip/task.yml
@@ -8,7 +8,6 @@ inputs:
 - name: blobstore-dav-cli
 - name: blobstore-s3-cli
 - name: blobstore-gcs-cli
-- name: windows-bsdtar
 - name: windows-winsw
 
 outputs:

--- a/ci/tasks/create-aws-stemcell/task.yml
+++ b/ci/tasks/create-aws-stemcell/task.yml
@@ -12,7 +12,6 @@ inputs:
   - name: blobstore-dav-cli
   - name: blobstore-s3-cli
   - name: blobstore-gcs-cli
-  - name: windows-bsdtar
   - name: windows-winsw
 
 outputs:

--- a/ci/tasks/create-azure-stemcell/task.yml
+++ b/ci/tasks/create-azure-stemcell/task.yml
@@ -11,7 +11,6 @@ inputs:
   - name: blobstore-dav-cli
   - name: blobstore-s3-cli
   - name: blobstore-gcs-cli
-  - name: windows-bsdtar
   - name: windows-winsw
 
 

--- a/ci/tasks/create-gcp-stemcell/task.yml
+++ b/ci/tasks/create-gcp-stemcell/task.yml
@@ -12,7 +12,6 @@ inputs:
   - name: blobstore-dav-cli
   - name: blobstore-s3-cli
   - name: blobstore-gcs-cli
-  - name: windows-bsdtar
   - name: windows-winsw
 
 outputs:

--- a/ci/tasks/test-stemcell-builder/task.yml
+++ b/ci/tasks/test-stemcell-builder/task.yml
@@ -11,7 +11,6 @@ inputs:
   - name: blobstore-dav-cli
   - name: blobstore-s3-cli
   - name: blobstore-gcs-cli
-  - name: windows-bsdtar
   - name: windows-winsw
 
 run:

--- a/modules/BOSH.Agent/BOSH.Agent.Tests.ps1
+++ b/modules/BOSH.Agent/BOSH.Agent.Tests.ps1
@@ -61,7 +61,6 @@ Describe "BOSH.Account" {
             $depsDir = (Join-Path $vcapDir "bin")
             Test-Path (Join-Path $depsDir "job-service-wrapper.exe") | Should -Be $True
             Test-Path (Join-Path $depsDir "pipe.exe") | Should -Be $True
-            Test-Path (Join-Path $depsDir "tar.exe") | Should -Be $True
             Test-Path (Join-Path $depsDir "bosh-blobstore-dav.exe") | Should -Be $True
             Test-Path (Join-Path $depsDir "bosh-blobstore-s3.exe") | Should -Be $True
             Test-Path (Join-Path $depsDir "bosh-blobstore-gcs.exe") | Should -Be $True

--- a/stembuild/README.md
+++ b/stembuild/README.md
@@ -254,7 +254,6 @@ You will need to construct `assets/StemcellAutomation.zip`. This file represents
 | deps/bosh-blobstore-gcs.exe  | https://github.com/cloudfoundry/bosh-gcscli |
 | deps/bosh-blobstore-dav.exe  | https://github.com/cloudfoundry/bosh-davcli |
 | deps/bosh-blobstore-s3.exe   | https://github.com/cloudfoundry/bosh-s3cli |
-| deps/tar.exe                 | https://github.com/cloudfoundry/bsdtar/ |
 | deps/job-service-wrapper.exe | https://github.com/bosh-dep-forks/winsw |
 | service_wrapper.exe          | https://github.com/bosh-dep-forks/winsw |
 | service_wrapper.xml          | https://github.com/cloudfoundry/bosh-agent/blob/main/integration/windows/fixtures/service_wrapper.xml |


### PR DESCRIPTION
BSD tar is included by default in newer Windows versions.