### PR TITLE
Fix building to work with symlink to system tar in bosh bin dir

### DIFF
--- a/modules/BOSH.Agent/BOSH.Agent.psm1
+++ b/modules/BOSH.Agent/BOSH.Agent.psm1
@@ -68,7 +68,7 @@ function Copy-Agent
     Move-Item (Join-Path $boshDir (Join-Path "deps" "*")) $depsDir
     Remove-Item -Path (Join-Path $boshDir "deps") -Force
 
-    New-Item -Path (Join-Path $depsDir "tar.exe") -ItemType SymbolicLink -V "C:\Windows\system32\tar.exe"
+    Copy-Item "C:\Windows\system32\tar.exe" -Destination (Join-Path $depsDir "tar.exe")
 }
 
 

--- a/modules/BOSH.Agent/BOSH.Agent.psm1
+++ b/modules/BOSH.Agent/BOSH.Agent.psm1
@@ -68,6 +68,11 @@ function Copy-Agent
     Move-Item (Join-Path $boshDir (Join-Path "deps" "*")) $depsDir
     Remove-Item -Path (Join-Path $boshDir "deps") -Force
 
+    # Although we previously removed bsdtar in favor of the system tar that
+    # comes with windows, some older garden-runc releases (< v1.76.0) still
+    # expect tar to live there. This preserves backwards compatability. We can
+    # likely rip this out again once we're out of some reasonable window where
+    # someone will still be running an older garden-runc release
     Copy-Item "C:\Windows\system32\tar.exe" -Destination (Join-Path $depsDir "tar.exe")
 }
 

--- a/modules/BOSH.Agent/BOSH.Agent.psm1
+++ b/modules/BOSH.Agent/BOSH.Agent.psm1
@@ -68,7 +68,7 @@ function Copy-Agent
     Move-Item (Join-Path $boshDir (Join-Path "deps" "*")) $depsDir
     Remove-Item -Path (Join-Path $boshDir "deps") -Force
 
-    Copy-Item "C:\Windows\system32\tar.exe" -Destination (Join-Path $depsDir "tar.exe")
+    New-Item -Path (Join-Path $depsDir "tar.exe") -ItemType SymbolicLink -V "C:\Windows\system32\tar.exe"
 }
 
 

--- a/modules/BOSH.Utils/BOSH.Utils.psm1
+++ b/modules/BOSH.Utils/BOSH.Utils.psm1
@@ -101,21 +101,21 @@ function Protect-Dir
     )
 
     Write-Log "Protect-Dir: Grant Administrator"
-    cmd.exe /c cacls.exe $path /T /E /P Administrators:F
+    cmd.exe /c icacls.exe $path /T /L /inheritancelevel:e /grant:r Administrators:F
     if ($LASTEXITCODE -ne 0)
     {
         Throw "Error setting ACL for $path exited with $LASTEXITCODE"
     }
 
     Write-Log "Protect-Dir: Remove BUILTIN\Users"
-    cmd.exe /c cacls.exe $path /T /E /R "BUILTIN\Users"
+    cmd.exe /c icacls.exe $path /T /L /inheritancelevel:r /remove:g "BUILTIN\Users"
     if ($LASTEXITCODE -ne 0)
     {
         Throw "Error setting ACL for $path exited with $LASTEXITCODE"
     }
 
     Write-Log "Protect-Dir: Remove BUILTIN\IIS_IUSRS"
-    cmd.exe /c cacls.exe $path /T /E /R "BUILTIN\IIS_IUSRS"
+    cmd.exe /c icacls.exe $path /T /L /inheritancelevel:r /remove:g "BUILTIN\IIS_IUSRS"
     if ($LASTEXITCODE -ne 0)
     {
         Throw "Error setting ACL for $path exited with $LASTEXITCODE"
@@ -138,21 +138,21 @@ function Protect-Path
     )
 
     Write-Log "Protect-Path: Grant Administrator"
-    cmd.exe /c cacls.exe $path /E /P Administrators:F
+    cmd.exe /c icacls.exe $path /L /grant:r Administrators:F
     if ($LASTEXITCODE -ne 0)
     {
         Throw "Error setting ACL for $path exited with $LASTEXITCODE"
     }
 
     Write-Log "Protect-Path: Remove BUILTIN\Users"
-    cmd.exe /c cacls.exe $path /E /R "BUILTIN\Users"
+    cmd.exe /c cacls.exe $path /L /remove:g "BUILTIN\Users"
     if ($LASTEXITCODE -ne 0)
     {
         Throw "Error setting ACL for $path exited with $LASTEXITCODE"
     }
 
     Write-Log "Protect-Path: Remove BUILTIN\IIS_IUSRS"
-    cmd.exe /c cacls.exe $path /E /R "BUILTIN\IIS_IUSRS"
+    cmd.exe /c cacls.exe $path /L /remove:g "BUILTIN\IIS_IUSRS"
     if ($LASTEXITCODE -ne 0)
     {
         Throw "Error setting ACL for $path exited with $LASTEXITCODE"

--- a/modules/BOSH.Utils/BOSH.Utils.psm1
+++ b/modules/BOSH.Utils/BOSH.Utils.psm1
@@ -101,21 +101,21 @@ function Protect-Dir
     )
 
     Write-Log "Protect-Dir: Grant Administrator"
-    cmd.exe /c icacls.exe $path /T /L /inheritancelevel:e /grant:r Administrators:F
+    cmd.exe /c cacls.exe $path /T /E /P Administrators:F
     if ($LASTEXITCODE -ne 0)
     {
         Throw "Error setting ACL for $path exited with $LASTEXITCODE"
     }
 
     Write-Log "Protect-Dir: Remove BUILTIN\Users"
-    cmd.exe /c icacls.exe $path /T /L /inheritancelevel:r /remove:g "BUILTIN\Users"
+    cmd.exe /c cacls.exe $path /T /E /R "BUILTIN\Users"
     if ($LASTEXITCODE -ne 0)
     {
         Throw "Error setting ACL for $path exited with $LASTEXITCODE"
     }
 
     Write-Log "Protect-Dir: Remove BUILTIN\IIS_IUSRS"
-    cmd.exe /c icacls.exe $path /T /L /inheritancelevel:r /remove:g "BUILTIN\IIS_IUSRS"
+    cmd.exe /c cacls.exe $path /T /E /R "BUILTIN\IIS_IUSRS"
     if ($LASTEXITCODE -ne 0)
     {
         Throw "Error setting ACL for $path exited with $LASTEXITCODE"
@@ -138,21 +138,21 @@ function Protect-Path
     )
 
     Write-Log "Protect-Path: Grant Administrator"
-    cmd.exe /c icacls.exe $path /L /grant:r Administrators:F
+    cmd.exe /c cacls.exe $path /E /P Administrators:F
     if ($LASTEXITCODE -ne 0)
     {
         Throw "Error setting ACL for $path exited with $LASTEXITCODE"
     }
 
     Write-Log "Protect-Path: Remove BUILTIN\Users"
-    cmd.exe /c cacls.exe $path /L /remove:g "BUILTIN\Users"
+    cmd.exe /c cacls.exe $path /E /R "BUILTIN\Users"
     if ($LASTEXITCODE -ne 0)
     {
         Throw "Error setting ACL for $path exited with $LASTEXITCODE"
     }
 
     Write-Log "Protect-Path: Remove BUILTIN\IIS_IUSRS"
-    cmd.exe /c cacls.exe $path /L /remove:g "BUILTIN\IIS_IUSRS"
+    cmd.exe /c cacls.exe $path /E /R "BUILTIN\IIS_IUSRS"
     if ($LASTEXITCODE -ne 0)
     {
         Throw "Error setting ACL for $path exited with $LASTEXITCODE"


### PR DESCRIPTION
* copy system tar to bosh bin, stemcell building process Protect_Dir behavior didn't like the symlink I added in https://github.com/cloudfoundry/bosh-windows-stemcell-builder/pull/101.
* I believe this is because the cacls/icacls commands in `Protect-Dir` and `Protect-Path` would try to follow that link into `C:\Windows\System32`, and messing with ACLs on that dir wasn't a good idea.
* I tried using the /L flag on cacls/icacls so that it would just stop at the link, but this led to some issues with the ACLs on the other linked dirs (`var\vcap\data`, `var\vcap\sys`, etc). Basically, we would see that anything added in the `var\vcap\packages` or `var\vcap\sys` would still have ACLS for `BUILTIN\Users`. I'm thinking that the existing implementation expects to be able to traverse links, which in the case of the data dir would be fine. Tried to get things working by messing with various cacls/icacls flags for inheritance, but after burning a couple days on it, decided it wasn't worth more effort. I think if we really wanted to do this, we'd have to add more granular ways to set permissions on things. But, considering we're gonna rip this out in the future anyway, I'm not sure it is worth it.
* I left some a comment explaining why that line is there, and then I'll squash this but leave a pretty thorough commit message. Hopefully that is enough to remind future us what this was for and what the criteria for removing it are