### PR TITLE
ci: update azs

### DIFF
--- a/ci/pipelines/stemcells-windows.yml
+++ b/ci/pipelines/stemcells-windows.yml
@@ -2007,7 +2007,7 @@ jobs:
       input_mapping: { stemcell: bosh-windows-stemcell }
       params:
         ACCOUNT_JSON: ((broadcom_labs_gcp_credentials_json))
-        AZ: az1
+        AZ: z1
         BOSH_CA_CERT: ((iaas_directors_labs-gcp-director_bosh_ca_cert.ca))
         BOSH_CLIENT: ((iaas_directors_labs-gcp-director_bosh_client.username))
         BOSH_CLIENT_SECRET: ((iaas_directors_labs-gcp-director_bosh_client.password))
@@ -2049,7 +2049,7 @@ jobs:
       image: bosh-integration-registry-image
       input_mapping: { stemcell: bosh-windows-stemcell }
       params:
-        AZ: az1
+        AZ: z1
         BOSH_CA_CERT: ((iaas_directors_labs-gcp-director_bosh_ca_cert.ca))
         BOSH_CLIENT: ((iaas_directors_labs-gcp-director_bosh_client.username))
         BOSH_CLIENT_SECRET: ((iaas_directors_labs-gcp-director_bosh_client.password))


### PR DESCRIPTION
* this pipeline uses the labs-gcp director. Update az name used because we are changing the labs-gcp director cloudconfig to use z1 instead of az1 to better match our other iaas directors