### PR TITLE
Fix azure packer plugin output parsing

### DIFF
--- a/lib/stemcell/builder/azure.rb
+++ b/lib/stemcell/builder/azure.rb
@@ -72,9 +72,11 @@ module Stemcell
         def parse_disk_uri(line)
           return unless line.include?("azure-arm,artifact,0") && line.include?("OSDiskUri:")
 
-          os_disk_uri = (line.split '\n').select do |s|
-            s.start_with?("OSDiskUri: ")
-          end.first.gsub("OSDiskUri: ", "").strip
+          os_disk_uri = line.split('\n')
+                          .find { |s| s.match?("OSDiskUri") }
+                          .split(": ")
+                          .last
+                          .strip
 
           create_signed_url(os_disk_uri)
         end

--- a/spec/stemcell/builder/azure_spec.rb
+++ b/spec/stemcell/builder/azure_spec.rb
@@ -19,7 +19,7 @@ describe Stemcell::Builder do
         command = 'build'
         manifest_contents = 'manifest_contents'
         packer_vars = {some_var: 'some-value'}
-        disk_image_url = 'some-disk-image-url'
+        disk_image_url = 'https://some-disk-image-url'
         client_id = 'some-client-id'
         client_secret = 'some-client-secret'
         tenant_id = 'some-tenant-id'
@@ -32,7 +32,7 @@ describe Stemcell::Builder do
         offer = 'some-offer'
         sku = 'some-sku'
         vm_prefix = 'some-vm-prefix'
-        packer_output = "azure-arm,artifact,0\\nOSDiskUri: #{disk_image_url}"
+        packer_output = "azure-arm,artifact,0\\nVHDOSDiskUri: #{disk_image_url}"
 
         packer_config = double(:packer_config)
         allow(packer_config).to receive(:dump).and_return(config)


### PR DESCRIPTION
A feature was added to the azure packer plugin to support multiple output formats.  As part of this change, the expected "OSDiskUri" log message was namespaced to "VHDOSDiskUri".

We made this code a bit more resilient, and it looks for a match instead of a exact starting string.

ref: https://github.com/hashicorp/packer-plugin-azure/pull/522