### PR TITLE
Use SAS token for copying from unpublishedstemcells

### DIFF
--- a/ci/tasks/azure-image-upload-and-start-publishing/run
+++ b/ci/tasks/azure-image-upload-and-start-publishing/run
@@ -85,11 +85,20 @@ update_offer() {
 
 
 copy_blob_to_premiumstore() {
+  # Generate SAS token for source blob
+  source_sas=$(az storage blob generate-sas \
+    --account-name "${AZURE_STORAGE_ACCOUNT}" \
+    --account-key "${AZURE_STORAGE_ACCESS_KEY}" \
+    --container-name "${AZURE_CONTAINER_NAME}" \
+    --name "${vhd_path}" \
+    --permissions r \
+    --expiry $(date -u -d "+1 hour" '+%Y-%m-%dT%H:%M:%SZ') \
+    --output tsv)
+
+  source_url="https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_CONTAINER_NAME}/${vhd_path}?${source_sas}"
+
   az storage blob copy start \
-    --source-account-key "${AZURE_STORAGE_ACCESS_KEY}" \
-    --source-account-name "${AZURE_STORAGE_ACCOUNT}" \
-    --source-container "${AZURE_CONTAINER_NAME}" \
-    --source-blob "${vhd_path}" \
+    --source-uri "${source_url}" \
     --account-name "${AZURE_PUBLISHED_STORAGE_ACCOUNT}" \
     --account-key "${AZURE_PUBLISHED_STORAGE_ACCESS_KEY}" \
     --destination-container "${AZURE_CONTAINER_NAME}" \


### PR DESCRIPTION
Apparently, with newer versions of the Azure CLI, the blob copying command will not work unless you grant the Azure storage service explicit access to read the source blob.