### PR TITLE
Fix bundler deprecation

### DIFF
--- a/ci/tasks/copy-aws-stemcell/run
+++ b/ci/tasks/copy-aws-stemcell/run
@@ -20,7 +20,7 @@ else
 fi
 
 pushd stemcell-builder
-  bundle install --without test
+  bundle install
   rake build:aws_ami
 
   mv copied-regional-stemcells/*.tgz ../copied-regional-stemcells

--- a/ci/tasks/copy-aws-stemcell/run
+++ b/ci/tasks/copy-aws-stemcell/run
@@ -21,7 +21,6 @@ fi
 
 pushd stemcell-builder
   bundle install --without test
-
   rake build:aws_ami
 
   mv copied-regional-stemcells/*.tgz ../copied-regional-stemcells

--- a/ci/tasks/create-aws-stemcell/run
+++ b/ci/tasks/create-aws-stemcell/run
@@ -34,7 +34,6 @@ pushd stemcell-builder
   cp "${CONCOURSE_ROOT}/psmodules-zip-output/bosh-psmodules.zip" "${CONCOURSE_ROOT}/bosh-agent/agent.zip" build
 
   bundle install --without test
-
   rake build:aws
 
   mv bosh-windows-stemcell/* ../bosh-windows-stemcell

--- a/ci/tasks/create-aws-stemcell/run
+++ b/ci/tasks/create-aws-stemcell/run
@@ -33,7 +33,7 @@ pushd stemcell-builder
   mkdir -p build
   cp "${CONCOURSE_ROOT}/psmodules-zip-output/bosh-psmodules.zip" "${CONCOURSE_ROOT}/bosh-agent/agent.zip" build
 
-  bundle install --without test
+  bundle install
   rake build:aws
 
   mv bosh-windows-stemcell/* ../bosh-windows-stemcell

--- a/ci/tasks/create-azure-stemcell/run
+++ b/ci/tasks/create-azure-stemcell/run
@@ -12,7 +12,7 @@ pushd stemcell-builder
   mkdir -p build
   cp "${CONCOURSE_ROOT}/psmodules-zip-output/bosh-psmodules.zip" "${CONCOURSE_ROOT}/bosh-agent/agent.zip" build
 
-  bundle install --without test
+  bundle install
   rake build:azure
 
   mv bosh-windows-stemcell/* ../bosh-windows-stemcell

--- a/ci/tasks/create-azure-stemcell/run
+++ b/ci/tasks/create-azure-stemcell/run
@@ -13,7 +13,6 @@ pushd stemcell-builder
   cp "${CONCOURSE_ROOT}/psmodules-zip-output/bosh-psmodules.zip" "${CONCOURSE_ROOT}/bosh-agent/agent.zip" build
 
   bundle install --without test
-
   rake build:azure
 
   mv bosh-windows-stemcell/* ../bosh-windows-stemcell

--- a/ci/tasks/create-gcp-stemcell/run
+++ b/ci/tasks/create-gcp-stemcell/run
@@ -13,7 +13,6 @@ pushd stemcell-builder
   cp "${CONCOURSE_ROOT}/psmodules-zip-output/bosh-psmodules.zip" "${CONCOURSE_ROOT}/bosh-agent/agent.zip" build
 
   bundle install --without test
-
   rake build:gcp
 
   mv bosh-windows-stemcell/* ../bosh-windows-stemcell

--- a/ci/tasks/create-gcp-stemcell/run
+++ b/ci/tasks/create-gcp-stemcell/run
@@ -12,7 +12,7 @@ pushd stemcell-builder
   mkdir -p build
   cp "${CONCOURSE_ROOT}/psmodules-zip-output/bosh-psmodules.zip" "${CONCOURSE_ROOT}/bosh-agent/agent.zip" build
 
-  bundle install --without test
+  bundle install
   rake build:gcp
 
   mv bosh-windows-stemcell/* ../bosh-windows-stemcell

--- a/ci/tasks/label-aws-stemcell-for-production/run
+++ b/ci/tasks/label-aws-stemcell-for-production/run
@@ -11,6 +11,7 @@ aws_access_key_id = ${AWS_ACCESS_KEY}
 aws_secret_access_key = ${AWS_SECRET_KEY}
 EOF
 
-cd stemcell-builder
-bundle install --without test
-rake aws:label:for_production
+pushd stemcell-builder
+  bundle install --without test
+  rake aws:label:for_production
+popd

--- a/ci/tasks/label-aws-stemcell-for-production/run
+++ b/ci/tasks/label-aws-stemcell-for-production/run
@@ -12,6 +12,6 @@ aws_secret_access_key = ${AWS_SECRET_KEY}
 EOF
 
 pushd stemcell-builder
-  bundle install --without test
+  bundle install
   rake aws:label:for_production
 popd

--- a/ci/tasks/wait-for-ami-availability/run
+++ b/ci/tasks/wait-for-ami-availability/run
@@ -17,7 +17,8 @@ else
   aws configure set aws_secret_access_key "${AWS_SECRET_KEY}"
 fi
 
-cd stemcell-builder
-bundle install --without test
-rake build:validate_ami
-rake aws:label:for_test
+pushd stemcell-builder
+  bundle install --without test
+  rake build:validate_ami
+  rake aws:label:for_test
+popd

--- a/ci/tasks/wait-for-ami-availability/run
+++ b/ci/tasks/wait-for-ami-availability/run
@@ -18,7 +18,7 @@ else
 fi
 
 pushd stemcell-builder
-  bundle install --without test
+  bundle install
   rake build:validate_ami
   rake aws:label:for_test
 popd


### PR DESCRIPTION
Fixes:

```
+ bundle install --without test
The `--without` flag has been removed because it relied on being remembered across bundler invocations, which bundler no longer does. Instead please use `bundle config set without 'test'`, and stop using this flag
```