### PR TITLE
Remove ProvisionerFactory

### DIFF
--- a/lib/packer/config.rb
+++ b/lib/packer/config.rb
@@ -1,5 +1,5 @@
 require "securerandom"
-require_relative "config/provisioners"
+require_relative "config/provisioner"
 require_relative "config/aws"
 require_relative "config/azure"
 require_relative "config/gcp"

--- a/lib/packer/config/aws.rb
+++ b/lib/packer/config/aws.rb
@@ -46,7 +46,7 @@ module Packer
       end
 
       def provisioners
-        ProvisionerFactory.new(@os, "aws", @mount_ephemeral_disk, @version).dump
+        Provisioner.new(@os, "aws", @mount_ephemeral_disk, @version).dump
       end
 
       def dump

--- a/lib/packer/config/azure.rb
+++ b/lib/packer/config/azure.rb
@@ -51,7 +51,7 @@ module Packer
       end
 
       def provisioners
-        ProvisionerFactory.new(@os, "azure", @mount_ephemeral_disk, @version).dump
+        Provisioner.new(@os, "azure", @mount_ephemeral_disk, @version).dump
       end
 
       def dump

--- a/lib/packer/config/gcp.rb
+++ b/lib/packer/config/gcp.rb
@@ -70,7 +70,7 @@ module Packer
       end
 
       def provisioners
-        ProvisionerFactory.new(@os, "gcp", @mount_ephemeral_disk, @version).dump
+        Provisioner.new(@os, "gcp", @mount_ephemeral_disk, @version).dump
       end
 
       def dump

--- a/lib/packer/config/provisioner.rb
+++ b/lib/packer/config/provisioner.rb
@@ -1,16 +1,5 @@
 require "securerandom"
 
-class ProvisionerFactory
-  def initialize(os, iaas, enable_ephemeral_disk, version, http_proxy = nil, https_proxy = nil, bypass_list = nil, build_context = nil)
-    klass = "OS#{os}"
-    @provisioner = Object.const_get(klass).new(os, iaas, enable_ephemeral_disk, version, http_proxy, https_proxy, bypass_list, build_context)
-  end
-
-  def dump
-    @provisioner.dump
-  end
-end
-
 class Provisioner
   def initialize(os, iaas, enable_ephemeral_disk, version, http_proxy = nil, https_proxy = nil, bypass_list = nil, build_context = nil)
     @iaas = iaas
@@ -22,9 +11,7 @@ class Provisioner
     filename = File.expand_path("../templates/provision_#{os}.json.erb", __FILE__)
     @erb = ERB.new(File.read(filename))
   end
-end
 
-class OSwindows2019 < Provisioner
   def dump
     result = @erb.result_with_hash({
       iaas: @iaas,


### PR DESCRIPTION
Currently there is only one supported windows os, in the future we intend to use branch, similar to the linux stembuilder, for OS lines.