### PR TITLE
Pin http-cookie < 1.1 for delete-vms task on Ruby 3.4

### DIFF
--- a/ci/tasks/delete-vms/Gemfile
+++ b/ci/tasks/delete-vms/Gemfile
@@ -1,5 +1,9 @@
 source "https://rubygems.org"
 
+# http-cookie >= 1.1 eagerly requires cookie_jar before HTTP::Cookie constants exist,
+# which raises NameError on Ruby 3.4+ when loaded via faraday-cookie_jar (Azure SDK).
+gem "http-cookie", "< 1.1"
+
 gem "aws-sdk"
 gem "azure_mgmt_resources"
 gem "nokogiri"


### PR DESCRIPTION
http-cookie 1.1+ requires cookie_jar before HTTP::Cookie defines MAX_COOKIES_TOTAL, which breaks when Azure/ms_rest loads Faraday’s cookie jar. 1.0.x autoloads CookieJar after the class is defined.

Fixes delete-orphan-vms NameError after successful Packer runs.

hopefully we can remove this once fixed upstream: https://github.com/sparklemotion/http-cookie/issues/62

https://ci.bosh-ecosystem.cf-app.com/teams/main/pipelines/stemcells-windows-2019/jobs/create-azure/builds/215