### PR TITLE
ci: fix encoding for hotfix output

### DIFF
--- a/ci/tasks/install-windows-updates/run.sh
+++ b/ci/tasks/install-windows-updates/run.sh
@@ -142,7 +142,7 @@ done
 
 remote_hotfix_log_path="C:\\hotfix.log"
 
-run_powershell_command_with_logging "Get-Hotfix > ${remote_hotfix_log_path}"
+run_powershell_command_with_logging "Get-Hotfix | Out-File -FilePath ${remote_hotfix_log_path} -Encoding utf8"
 
 download_remote_file "${remote_hotfix_log_path}" hotfix-log/hotfixes.log
 

--- a/lib/packer/config/templates/provision_windows2019.json.erb
+++ b/lib/packer/config/templates/provision_windows2019.json.erb
@@ -111,7 +111,7 @@
     "inline": [
       "$ErrorActionPreference = \"Stop\";",
       "trap { $host.SetShouldExit(1) }",
-      "Get-HotFix > hotfixes.log"
+      "Get-HotFix | Out-File -FilePath hotfixes.log -Encoding utf8"
     ]
   },
   {

--- a/spec/packer/config/aws_spec.rb
+++ b/spec/packer/config/aws_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe Packer::Config::Aws do
         {"type" => "powershell", "inline" => ["$ErrorActionPreference = \"Stop\";", "trap { $host.SetShouldExit(1) }", "Wait-WindowsUpdates -Password some-password! -User Provisioner"]},
         {"type" => "windows-restart", "restart_timeout" => "12h", "check_registry" => true},
         {"type" => "powershell", "inline" => ["$ErrorActionPreference = \"Stop\";", "trap { $host.SetShouldExit(1) }", "Unregister-WindowsUpdatesTask"]},
-        {"type" => "powershell", "inline" => ["$ErrorActionPreference = \"Stop\";", "trap { $host.SetShouldExit(1) }", "Get-HotFix > hotfixes.log"]},
+        {"type" => "powershell", "inline" => ["$ErrorActionPreference = \"Stop\";", "trap { $host.SetShouldExit(1) }", "Get-HotFix | Out-File -FilePath hotfixes.log -Encoding utf8"]},
         {"type" => "file", "source" => "hotfixes.log", "destination" => "hotfixes.log", "direction" => "download"},
         {"type" => "powershell", "inline" => ["$ErrorActionPreference = \"Stop\";", "trap { $host.SetShouldExit(1) }", "Remove-Account -User Provisioner"]},
         {"type" => "file", "source" => "../sshd/OpenSSH-Win64.zip", "destination" => "C:\\provision\\OpenSSH-Win64.zip"},

--- a/spec/packer/config/azure_spec.rb
+++ b/spec/packer/config/azure_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe Packer::Config::Azure do
         {"type" => "powershell", "inline" => ["$ErrorActionPreference = \"Stop\";", "trap { $host.SetShouldExit(1) }", "Wait-WindowsUpdates -Password some-password! -User Provisioner"]},
         {"type" => "windows-restart", "restart_timeout" => "12h", "check_registry" => true},
         {"type" => "powershell", "inline" => ["$ErrorActionPreference = \"Stop\";", "trap { $host.SetShouldExit(1) }", "Unregister-WindowsUpdatesTask"]},
-        {"type" => "powershell", "inline" => ["$ErrorActionPreference = \"Stop\";", "trap { $host.SetShouldExit(1) }", "Get-HotFix > hotfixes.log"]},
+        {"type" => "powershell", "inline" => ["$ErrorActionPreference = \"Stop\";", "trap { $host.SetShouldExit(1) }", "Get-HotFix | Out-File -FilePath hotfixes.log -Encoding utf8"]},
         {"type" => "file", "source" => "hotfixes.log", "destination" => "hotfixes.log", "direction" => "download"},
         {"type" => "powershell", "inline" => ["$ErrorActionPreference = \"Stop\";", "trap { $host.SetShouldExit(1) }", "Remove-Account -User Provisioner"]},
         {"type" => "file", "source" => "../sshd/OpenSSH-Win64.zip", "destination" => "C:\\provision\\OpenSSH-Win64.zip"},

--- a/spec/packer/config/gcp_spec.rb
+++ b/spec/packer/config/gcp_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe Packer::Config::Gcp do
         {"type" => "powershell", "inline" => ["$ErrorActionPreference = \"Stop\";", "trap { $host.SetShouldExit(1) }", "Wait-WindowsUpdates -Password some-password! -User Provisioner"]},
         {"type" => "windows-restart", "restart_timeout" => "12h", "check_registry" => true},
         {"type" => "powershell", "inline" => ["$ErrorActionPreference = \"Stop\";", "trap { $host.SetShouldExit(1) }", "Unregister-WindowsUpdatesTask"]},
-        {"type" => "powershell", "inline" => ["$ErrorActionPreference = \"Stop\";", "trap { $host.SetShouldExit(1) }", "Get-HotFix > hotfixes.log"]},
+        {"type" => "powershell", "inline" => ["$ErrorActionPreference = \"Stop\";", "trap { $host.SetShouldExit(1) }", "Get-HotFix | Out-File -FilePath hotfixes.log -Encoding utf8"]},
         {"type" => "file", "source" => "hotfixes.log", "destination" => "hotfixes.log", "direction" => "download"},
         {"type" => "powershell", "inline" => ["$ErrorActionPreference = \"Stop\";", "trap { $host.SetShouldExit(1) }", "Remove-Account -User Provisioner"]},
         {"type" => "file", "source" => "../sshd/OpenSSH-Win64.zip", "destination" => "C:\\provision\\OpenSSH-Win64.zip"},

--- a/spec/support/provisioners_shared_examples.rb
+++ b/spec/support/provisioners_shared_examples.rb
@@ -31,13 +31,13 @@ RSpec.shared_examples "standard provisioners" do
   end
 
   it "runs get-hotfix after windows updates are applied" do
-    get_hotfix_prov = TestProvisioner.new_powershell_provisioner("Get-HotFix > hotfixes.log")
+    get_hotfix_prov = TestProvisioner.new_powershell_provisioner("Get-HotFix | Out-File -FilePath hotfixes.log -Encoding utf8")
     wait_windows_update_prov = TestProvisioner.new_powershell_provisioner(/Wait-WindowsUpdates -Password .+ -User Provisioner/)
     expect(provisioners).to include_provisioner(get_hotfix_prov, after: [wait_windows_update_prov])
     # expect(provisioners).to include_provisioner(get_hotfix_prov)
 
     prov_index = provisioners.find_index do |p|
-      p["type"] == "powershell" && p.has_key?("inline") && p["inline"].include?("Get-HotFix > hotfixes.log")
+      p["type"] == "powershell" && p.has_key?("inline") && p["inline"].include?("Get-HotFix | Out-File -FilePath hotfixes.log -Encoding utf8")
     end
     expect(prov_index).not_to be_nil, "Could not find Get-Hotfix provisioner"
 


### PR DESCRIPTION
renders weird in concourse with e x t r a  s p a c e s

<img width="1606" height="388" alt="image" src="https://github.com/user-attachments/assets/fa5eb0c2-d783-4cf0-9d52-3dbfe6491aaf" />


Still might be the BOM at the beginning, we're on Powershell 5.1 it seems. From cursor:
> Note: On Windows PowerShell 5.1, -Encoding utf8 for Out-File is typically UTF-8 with BOM, which is still fine for cat on Linux (you might see a harmless BOM at the very start in some viewers). PowerShell 7+ also supports utf8NoBOM if you ever want BOM-less output.