### PR TITLE
Grant Authenticated Users read-execute on Protect-Dir paths

### DIFF
--- a/acceptance_test/assets/bwats-release/jobs/check-system/templates/run.ps1
+++ b/acceptance_test/assets/bwats-release/jobs/check-system/templates/run.ps1
@@ -114,24 +114,22 @@ function Test-Dependencies {
 }
 
 function Test-Acls {
-    # Base allow list intentionally omits NT AUTHORITY\Authenticated Users so that
-    # any regression that re-grants write access to C:\bosh or C:\var is caught by CI.
+    # NT AUTHORITY\Authenticated Users is included in the allow list because Protect-Dir
+    # grants Read & Execute (RX) to ensure Windows services running as Network Service or
+    # Local Service can traverse PATH entries pointing into these directories without
+    # receiving ACCESS_DENIED during boot. Write access for Authenticated Users is caught
+    # by the guard inside Test-FolderAcls.
     $expectedacls = New-Object System.Collections.ArrayList
     [void] $expectedacls.AddRange((
             "${env:COMPUTERNAME}\Administrator,Allow",
             "NT AUTHORITY\SYSTEM,Allow",
             "BUILTIN\Administrators,Allow",
             "CREATOR OWNER,Allow",
+            "NT AUTHORITY\Authenticated Users,Allow",
             "APPLICATION PACKAGE AUTHORITY\ALL APPLICATION PACKAGES,Allow",
             "NT SERVICE\TrustedInstaller,Allow",
             "APPLICATION PACKAGE AUTHORITY\ALL RESTRICTED APPLICATION PACKAGES,Allow"
         ))
-
-    # OpenSSH files legitimately carry an Authenticated Users:R ACE placed by
-    # Invoke-CACL, so the OpenSSH directory uses its own extended allow list.
-    $opensshExpectedAcls = New-Object System.Collections.ArrayList
-    $opensshExpectedAcls.AddRange($expectedacls)
-    [void] $opensshExpectedAcls.Add("NT AUTHORITY\Authenticated Users,Allow")
 
     function Test-FolderAcls {
         param(
@@ -140,6 +138,16 @@ function Test-Acls {
         )
 
         $errCount = 0
+        # Forbidden bits: write, delete, and ACL/ownership changes — none of which RX grants,
+        # but we guard all of them so any future regression in the ACL is caught immediately.
+        $writeBits = [int]([System.Security.AccessControl.FileSystemRights]::WriteData) -bor
+                     [int]([System.Security.AccessControl.FileSystemRights]::AppendData) -bor
+                     [int]([System.Security.AccessControl.FileSystemRights]::WriteExtendedAttributes) -bor
+                     [int]([System.Security.AccessControl.FileSystemRights]::WriteAttributes) -bor
+                     [int]([System.Security.AccessControl.FileSystemRights]::Delete) -bor
+                     [int]([System.Security.AccessControl.FileSystemRights]::DeleteSubdirectoriesAndFiles) -bor
+                     [int]([System.Security.AccessControl.FileSystemRights]::ChangePermissions) -bor
+                     [int]([System.Security.AccessControl.FileSystemRights]::TakeOwnership)
 
         Get-ChildItem -Path $path -Recurse | ForEach-Object {
             $name = $_.FullName
@@ -149,6 +157,12 @@ function Test-Acls {
                     If (-Not $allowedAcls.Contains($ident)) {
                         $errCount += 1
                         Write-Host "Error ($name): $ident"
+                    }
+                    ElseIf ($_.IdentityReference -eq "NT AUTHORITY\Authenticated Users" -and $_.AccessControlType -eq "Allow") {
+                        If (([int]$_.FileSystemRights -band $writeBits) -ne 0) {
+                            $errCount += 1
+                            Write-Host "Error ($name): NT AUTHORITY\Authenticated Users has write access: $($_.FileSystemRights)"
+                        }
                     }
                 }
             }
@@ -160,7 +174,7 @@ function Test-Acls {
     $errCount += Test-FolderAcls "C:\var"                      $expectedacls
     $errCount += Test-FolderAcls "C:\bosh"                     $expectedacls
     $errCount += Test-FolderAcls "C:\Windows\Panther\Unattend" $expectedacls
-    $errCount += Test-FolderAcls "C:\Program Files\OpenSSH"    $opensshExpectedAcls
+    $errCount += Test-FolderAcls "C:\Program Files\OpenSSH"    $expectedacls
     if ($errCount -ne 0) {
         Write-Error "FAILED: $errCount"
         Exit 1

--- a/modules/BOSH.Utils/BOSH.Utils.Tests.ps1
+++ b/modules/BOSH.Utils/BOSH.Utils.Tests.ps1
@@ -162,7 +162,22 @@ Describe "BOSH.Utils" {
             $acl.AreAccessRulesProtected | Should -Be $True
             $acl.Access | where { $_.IdentityReference -eq "BUILTIN\Users" } | Should -BeNullOrEmpty
             $acl.Access | where { $_.IdentityReference -eq "BUILTIN\IIS_IUSRS" } | Should -BeNullOrEmpty
-            $acl.Access | where { $_.IdentityReference -eq "NT AUTHORITY\Authenticated Users" } | Should -BeNullOrEmpty
+            $authenticatedUsersAccesses = @($acl.Access | where { $_.IdentityReference -eq "NT AUTHORITY\Authenticated Users" -and $_.AccessControlType -eq "Allow" })
+            $authenticatedUsersAccesses | Should -Not -BeNullOrEmpty
+            # Every Allow ACE for Authenticated Users must carry Read & Execute only — no write,
+            # delete, or ACL/ownership rights — to prevent LPE (CWE-276). Checking all ACEs
+            # ensures a second permissive entry can't silently bypass this guard.
+            $forbiddenRights = [int]([System.Security.AccessControl.FileSystemRights]::WriteData) -bor
+                               [int]([System.Security.AccessControl.FileSystemRights]::AppendData) -bor
+                               [int]([System.Security.AccessControl.FileSystemRights]::WriteExtendedAttributes) -bor
+                               [int]([System.Security.AccessControl.FileSystemRights]::WriteAttributes) -bor
+                               [int]([System.Security.AccessControl.FileSystemRights]::Delete) -bor
+                               [int]([System.Security.AccessControl.FileSystemRights]::DeleteSubdirectoriesAndFiles) -bor
+                               [int]([System.Security.AccessControl.FileSystemRights]::ChangePermissions) -bor
+                               [int]([System.Security.AccessControl.FileSystemRights]::TakeOwnership)
+            foreach ($ace in $authenticatedUsersAccesses) {
+                ([int]($ace.FileSystemRights) -band $forbiddenRights) | Should -Be 0
+            }
             $systemAccess = ($acl.Access | where { $_.IdentityReference -eq "NT AUTHORITY\SYSTEM" -and $_.AccessControlType -eq "Allow" } | Select-Object -First 1)
             $systemAccess | Should -Not -BeNullOrEmpty
             $systemAccess.FileSystemRights | Should -Be "FullControl"

--- a/modules/BOSH.Utils/BOSH.Utils.psm1
+++ b/modules/BOSH.Utils/BOSH.Utils.psm1
@@ -102,13 +102,18 @@ function Protect-Dir
 
     if ($disableInheritance)
     {
-        # Replace the entire DACL with a tight, explicit ACL granting only SYSTEM and
-        # Administrators full control. /inheritance:r removes all inherited ACEs
-        # (including NT AUTHORITY\Authenticated Users:(OI)(CI)(IO)(M) inherited from C:\)
-        # and disables further inheritance so they cannot reappear. /grant:r replaces any
-        # pre-existing grants for these principals rather than appending. /T is recursive.
-        Write-Log "Protect-Dir: Set tight DACL on $path (remove inheritance, grant SYSTEM and Administrators only)"
-        cmd.exe /c icacls.exe $path /inheritance:r /grant:r "NT AUTHORITY\SYSTEM:(OI)(CI)F" "BUILTIN\Administrators:(OI)(CI)F" /T
+        # Replace the entire DACL via /inheritance:r (removes all inherited ACEs and
+        # disables further inheritance). /grant:r replaces any pre-existing grants for
+        # these principals rather than appending. /T applies the same ACL recursively
+        # to all child files and subdirectories.
+        #
+        # Authenticated Users is granted Read & Execute (RX) — no write — so that:
+        #   - Windows services running as Network Service or Local Service (both members
+        #     of Authenticated Users) can traverse PATH entries pointing into these dirs
+        #     without receiving ACCESS_DENIED during process creation at boot.
+        #   - Authenticated Users cannot write or modify files in these directories.
+        Write-Log "Protect-Dir: Set tight DACL on $path (disable inheritance, grant SYSTEM and Administrators full control, Authenticated Users read-only)"
+        & icacls.exe $path /inheritance:r /grant:r "NT AUTHORITY\SYSTEM:(OI)(CI)F" "BUILTIN\Administrators:(OI)(CI)F" "NT AUTHORITY\Authenticated Users:(OI)(CI)RX" /T
         if ($LASTEXITCODE -ne 0)
         {
             Throw "Error setting ACL for $path exited with $LASTEXITCODE"


### PR DESCRIPTION
Without Read & Execute for NT AUTHORITY\Authenticated Users on C:\bosh and C:\var, Windows services running as Network Service or Local Service (both members of Authenticated Users) receive ERROR_ACCESS_DENIED during process creation at boot, preventing the BOSH agent service from starting. Confirmed via System.evtx: %%5 (ERROR_ACCESS_DENIED) logged by the SCM against the bosh-agent service on affected stemcells.

The fix grants Authenticated Users RX (no write) via icacls /inheritance:r
- write access is still blocked — while restoring compatibility with Windows service startup machinery.

Unit test updated to assert Authenticated Users is present with Allow ACE but zero write bits. Acceptance test updated to include Authenticated Users in the allow list and guard against write-access regression.