### PR TITLE
Fix: address bundle config deprecation warning

### DIFF
--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -142,8 +142,8 @@ RUN cd /tmp  \
     && ruby-install --jobs=${NUM_CPUS} --cleanup --system ruby ${RUBY_VERSION} \
       -- --disable-install-doc --disable-install-rdoc \
     && gem update --system \
-    && bundle config --global path "${GEM_HOME}" \
-    && bundle config --global bin "${GEM_HOME}/bin"
+    && bundle config set --global path "${GEM_HOME}" \
+    && bundle config set --global bin "${GEM_HOME}/bin"
 
 
 RUN bosh_cli_path="/usr/bin/bosh" \


### PR DESCRIPTION
Addresses:
```
[DEPRECATED] Using the `config` command without a subcommand [list, get, set, unset] is deprecated and will be removed in the future. Use `bundle config set --global path /usr/local/bundle` instead.
```
... in ci image build