### PR TITLE
Potential fix for code scanning alert no. 4: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/stembuild/test/helpers/helpers.go
+++ b/stembuild/test/helpers/helpers.go
@@ -113,10 +113,15 @@ func extractArchive(archive io.Reader, dirname string) error {
 		if name == "" {
 			return errors.New("tar: archive contains empty filename")
 		}
-		if filepath.IsAbs(name) {
+		unifiedName := strings.ReplaceAll(name, "\\", "/")
+		// Reject absolute paths in both Unix and Windows forms (including UNC paths).
+		if strings.HasPrefix(unifiedName, "/") || filepath.IsAbs(filepath.FromSlash(unifiedName)) {
 			return fmt.Errorf("tar: archive contains absolute path: %s", name)
 		}
-		unifiedName := strings.ReplaceAll(name, "\\", "/")
+		// Reject Windows drive-relative / drive-absolute paths (e.g. "C:foo", "C:\\foo").
+		if vol := filepath.VolumeName(filepath.FromSlash(unifiedName)); vol != "" {
+			return fmt.Errorf("tar: archive contains volume name %q in path: %s", vol, name)
+		}
 		for _, part := range strings.Split(unifiedName, "/") {
 			if part == ".." {
 				return fmt.Errorf("tar: archive contains invalid path traversal: %s", name)

--- a/stembuild/test/helpers/helpers.go
+++ b/stembuild/test/helpers/helpers.go
@@ -110,6 +110,16 @@ func extractArchive(archive io.Reader, dirname string) error {
 
 		// expect a flat archive
 		name := h.Name
+		if name == "" {
+			return errors.New("tar: archive contains empty filename")
+		}
+		if filepath.IsAbs(name) {
+			return fmt.Errorf("tar: archive contains absolute path: %s", name)
+		}
+		normalizedName := filepath.Clean(strings.ReplaceAll(name, "\\", "/"))
+		if normalizedName == ".." || strings.HasPrefix(normalizedName, "../") || strings.Contains(normalizedName, "/../") {
+			return fmt.Errorf("tar: archive contains invalid path traversal: %s", name)
+		}
 		if filepath.Base(name) != name {
 			return fmt.Errorf("tar: archive contains subdirectory: %s", name)
 		}

--- a/stembuild/test/helpers/helpers.go
+++ b/stembuild/test/helpers/helpers.go
@@ -116,9 +116,11 @@ func extractArchive(archive io.Reader, dirname string) error {
 		if filepath.IsAbs(name) {
 			return fmt.Errorf("tar: archive contains absolute path: %s", name)
 		}
-		normalizedName := filepath.Clean(strings.ReplaceAll(name, "\\", "/"))
-		if normalizedName == ".." || strings.HasPrefix(normalizedName, "../") || strings.Contains(normalizedName, "/../") {
-			return fmt.Errorf("tar: archive contains invalid path traversal: %s", name)
+		unifiedName := strings.ReplaceAll(name, "\\", "/")
+		for _, part := range strings.Split(unifiedName, "/") {
+			if part == ".." {
+				return fmt.Errorf("tar: archive contains invalid path traversal: %s", name)
+			}
 		}
 		if filepath.Base(name) != name {
 			return fmt.Errorf("tar: archive contains subdirectory: %s", name)


### PR DESCRIPTION
> [!NOTE]
> Copilot generated fix

Potential fix for [https://github.com/cloudfoundry/bosh-windows-stemcell-builder/security/code-scanning/4](https://github.com/cloudfoundry/bosh-windows-stemcell-builder/security/code-scanning/4)

To fix this safely, validate each archive entry name with explicit deny rules before using it in any filesystem operation. Keep existing behavior (flat archive only) but add strict checks for:
- empty names
- absolute paths
- any `..` path segment (after normalization and slash unification)

Best targeted fix in `stembuild/test/helpers/helpers.go` inside `extractArchive`:
1. Right after `name := h.Name`, reject empty names.
2. Reject absolute paths with `filepath.IsAbs(name)`.
3. Normalize separators (`\` to `/`) and reject any path containing `..` segment.
4. Keep the existing flat-archive check (`filepath.Base(name) != name`) to preserve intended functionality.

No new imports are needed; `strings` and `filepath` are already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
