### PR TITLE
CI: Switch to Standard_D2ds_v5 Azure vm type

### DIFF
--- a/ci/pipelines/stemcells-windows.yml
+++ b/ci/pipelines/stemcells-windows.yml
@@ -1855,7 +1855,7 @@ jobs:
           STORAGE_ACCOUNT: unpublishedstemcells
           SUBSCRIPTION_ID: ((koala_azure_credentials_json.subscription_id))
           TENANT_ID: ((koala_azure_credentials_json.tenant_id))
-          VM_SIZE: Standard_DS2_v2
+          VM_SIZE: Standard_D2ds_v5
           VM_PREFIX: packer-prod-((BASE_OS_VERSION))
           MOUNT_EPHEMERAL_DISK: true
         ensure:


### PR DESCRIPTION
Standard_DS2_v2 is scheduled to be retired on 07/31/2026

ref https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/lifecycle/retirement/d-ds-dv2-dsv2-ls-series-migration-guide

(already flown)