### PR TITLE
Revert "Pin http-cookie < 1.1 for delete-vms task on Ruby 3.4"

### DIFF
--- a/ci/tasks/delete-vms/Gemfile
+++ b/ci/tasks/delete-vms/Gemfile
@@ -1,9 +1,5 @@
 source "https://rubygems.org"
 
-# http-cookie >= 1.1 eagerly requires cookie_jar before HTTP::Cookie constants exist,
-# which raises NameError on Ruby 3.4+ when loaded via faraday-cookie_jar (Azure SDK).
-gem "http-cookie", "< 1.1"
-
 gem "aws-sdk"
 gem "azure_mgmt_resources"
 gem "nokogiri"


### PR DESCRIPTION
Reverts cloudfoundry/bosh-windows-stemcell-builder#164

Looks like this was fixed in `1.1.5` https://github.com/sparklemotion/http-cookie/issues/62#issuecomment-4276035276